### PR TITLE
Update and rename article to 2011-03-10-smart-collapsing-ad.md

### DIFF
--- a/_posts/articles/2011-03-10-smart-collapsing-ad.md
+++ b/_posts/articles/2011-03-10-smart-collapsing-ad.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: "vidazoo-prod"
-excerpt: "vidazoo-prod"
+title: "smart-collapsing-ad"
+excerpt: "smart-collapsing-ad"
 categories: articles
 tags: [sample-post, video]
 comments: true
@@ -46,6 +46,6 @@ Occupy et selvage squid, pug brunch blog nesciunt hashtag mumblecore skateboard 
 Aliquip enim artisan dolor post-ironic. Pug tote bag Marfa, deserunt pour-over Portland wolf eu odio intelligentsia american apparel ugh ea. Sunt viral et, 3 wolf moon gastropub pug id. Id fashion axe est typewriter, mlkshk Portland art party aute brunch. Sint pork belly Cosby sweater, deep v mumblecore kitsch american apparel. Try-hard direct trade tumblr sint skateboard. Adipisicing bitters excepteur biodiesel, pickled gastropub aute veniam.
 <br>
 <div class="apester-media" data-media-id="5dc431a0daa23359fc27ba04" height="419"></div><script async 
-src="https://static.apester.com/js/sdk/latest/apester-sdk.js"></script>
+src="https://static.stg.apester.com/js/sdk/latest/apester-sdk.js"></script>
 <br>
 


### PR DESCRIPTION
The SDK `src` was updated to point to `stg` so we can send Smart a test page with unminified code for testing.